### PR TITLE
Magic Global Restructuring

### DIFF
--- a/src/clik/__init__.py
+++ b/src/clik/__init__.py
@@ -9,6 +9,5 @@ The command line interface kit.
 __version__ = '0.90.0'
 
 
-from clik.app import app  # noqa: F401
-from clik.command import catch  # noqa: F401
-from clik.magic import args, current_app, g, parser, run_children  # noqa: F401
+from clik.app import app, args, current_app, g, parser, run_children
+from clik.command import catch

--- a/src/test/unit/test_magic.py
+++ b/src/test/unit/test_magic.py
@@ -8,29 +8,33 @@ Test the :mod:`clik.magic` module.
 """
 import pytest
 
-from clik.magic import Context, Magic, MagicNameConflictError, \
-    UnboundMagicError, UnregisteredMagicNameError
+from clik.magic import Context, Magic, LockedMagicError, \
+    MagicNameConflictError, UnboundMagicError, UnregisteredMagicNameError
 
 
 def test_context():
     context = Context()
-    a = Magic('a', context)
-    with pytest.raises(MagicNameConflictError):
-        Magic('a', context)
-    with pytest.raises(UnboundMagicError):
-        assert a
-    with pytest.raises(UnboundMagicError):
-        context.pop('a')
-    with pytest.raises(UnregisteredMagicNameError):
-        context.get('z')
-    with pytest.raises(UnregisteredMagicNameError):
-        context.push('z', None)
-    with pytest.raises(UnregisteredMagicNameError):
-        context.pop('z')
-    with context(a=5):
-        assert a == 5
-        with context(a=10):
-            assert a == 10
-        assert a == 5
-    with pytest.raises(UnboundMagicError):
-        assert a
+    a = Magic('a')
+    with context.acquire(a):
+        with pytest.raises(LockedMagicError):
+            with context.acquire(a):
+                pass
+        with pytest.raises(MagicNameConflictError):
+            context.register('a')
+        with pytest.raises(UnboundMagicError):
+            assert a
+        with pytest.raises(UnboundMagicError):
+            context.pop('a')
+        with pytest.raises(UnregisteredMagicNameError):
+            context.get('z')
+        with pytest.raises(UnregisteredMagicNameError):
+            context.push('z', None)
+        with pytest.raises(UnregisteredMagicNameError):
+            context.pop('z')
+        with context(a=5):
+            assert a == 5
+            with context(a=10):
+                assert a == 10
+            assert a == 5
+        with pytest.raises(UnboundMagicError):
+            assert a


### PR DESCRIPTION
This commit extracts the global magic variables from `clik.magic` and reimplements them inside `clik.app`. This change does not affect end users of the library.

Honestly, the motivation was that I realized it could be done. It seemed simple enough and worth a shot. So I did, and the tests passed. And the resulting implementation looked good:

* `clik.magic` is now just a helper library; no clik-specific global state
* `clik.command` no longer imports / depends on `clik.magic` – the context is passed in from the caller (i.e. `clik.app.App`)
* Context is now tied to the app instance, which "feels more right"