### PR TITLE
Linter Violation Fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016-2017 Joe Joyce and contributors.
+Copyright 2009-2017 Joe Joyce and contributors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ $(PRE_PUSH) : $(ROOT)/Makefile
 	chmod +x $(PRE_PUSH)
 
 lint : env
-	$(FLAKE8) --ignore=D203 $(LINT_FILES)
+	@$(FLAKE8) --ignore=D203 $(LINT_FILES)
 	@printf "Flake8 is happy :)\n"
 
 test : lint

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ REQUIREMENTS = $(ROOT)/requirements.txt
 ENV_SOURCES = $(SETUP) $(REQUIREMENTS)
 CHANGELOG = $(ROOT)/CHANGELOG.rst
 README = $(ROOT)/README.rst
-SOURCES := $(shell find $(SRC) -name "*.py")
+SOURCES := $(shell find $(SRC)/clik $(SRC)/test/unit -name "*.py")
 LINT_FILES = $(DOC)/conf.py $(TOOL)/marc.py $(TOOL)/test $(SETUP) $(SOURCES)
 UPDATED_ENV = $(ENV)/updated
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,7 +3,7 @@
 Sphinx configuration file for clik.
 
 :author: Joe Joyce <joe@decafjoe.com>
-:copyright: Copyright (c) Joe Joyce, 2009-2017.
+:copyright: Copyright (c) Joe Joyce and contributors, 2009-2017.
 :license: BSD
 """
 import os

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     name=name,
     package_dir={'': 'src'},
     packages=find_packages('src'),
-    url='http://clik.readthedocs.io/',
+    url='http://clik.readthedocs.io',
     version=version,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 Package configuration for clik.
 
 :author: Joe Joyce <joe@decafjoe.com>
-:copyright: Copyright (c) Joe Joyce, 2009-2017.
+:copyright: Copyright (c) Joe Joyce and contributors, 2009-2017.
 :license: BSD
 """
 import sys

--- a/src/clik/__init__.py
+++ b/src/clik/__init__.py
@@ -15,5 +15,7 @@ modules within clik.
 __version__ = '0.90.0'
 
 
+# LINT: Ignore unused import violations. This module isn't meant to "do"
+#       anything, just to make clik's API available to the end user.
 from clik.app import app, args, current_app, g, parser, run_children  # noqa
 from clik.command import catch  # noqa: F401

--- a/src/clik/__init__.py
+++ b/src/clik/__init__.py
@@ -2,12 +2,18 @@
 """
 The command line interface kit.
 
+Clik is a tool for writing complex command-line interfaces with minimal
+boilerplate and bookkeeping.
+
+This top-level package pulls together the end user API from the various
+modules within clik.
+
 :author: Joe Joyce <joe@decafjoe.com>
-:copyright: Copyright (c) Joe Joyce, 2009-2017.
+:copyright: Copyright (c) Joe Joyce and contributors, 2009-2017.
 :license: BSD
 """
 __version__ = '0.90.0'
 
 
-from clik.app import app, args, current_app, g, parser, run_children
-from clik.command import catch
+from clik.app import app, args, current_app, g, parser, run_children  # noqa
+from clik.command import catch  # noqa: F401

--- a/src/clik/app.py
+++ b/src/clik/app.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """
-All the hackery that makes clik clik.
+Top-level :class:`App` class and helpers.
 
 :author: Joe Joyce <joe@decafjoe.com>
-:copyright: Copyright (c) Joe Joyce, 2009-2017.
+:copyright: Copyright (c) Joe Joyce and contributors, 2009-2017.
 :license: BSD
 """
 import sys
@@ -22,6 +22,31 @@ run_children = Magic('run_children')
 
 
 def app(fn=None, name=None):
+    """
+    Decorate the main application generator function.
+
+    If the decorator is given no arguments, the name of the application is the
+    name of the decorated generator function::
+
+        # Application will be named 'myapp' in this case
+        @app
+        def myapp():
+            yield
+
+    The application name can be set by passing a string to ``name``::
+
+        # Application will be named 'theapp' in this case
+        @app(name='theapp')
+        def myapp():
+            yield
+
+    :param fn: Main application generator function. Name of the application
+               will be set to ``fn.__name__``.
+    :param name: Overrides name of application. Must not be used with the
+                 ``fn`` argument (if used with ``fn``, ``name`` is ignored).
+    :return: :class:`App` if ``fn`` is data:`None`, otherwise decorator
+             returning :class:`App`.
+    """
     def decorate(fn):
         return App(fn, name)
     if fn is None:
@@ -30,21 +55,66 @@ def app(fn=None, name=None):
 
 
 class AttributeDict(dict):
+    """
+    Simple :class:`dict` wrapper that allows key access via attribute.
+
+    Example::
+
+        d = AttributeDict(foo='bar', baz='qux')
+        d['foo']      # 'bar'
+        d.foo         # 'bar'
+        d['baz']      # 'qux'
+        d.baz         # 'qux'
+        d.foo = 'bup'
+        d['foo']      # 'bup'
+        d.foo         # 'bup'
+        del d.foo
+        d.foo         # KeyError
+
+    """
+
     def __getattr__(self, name):
+        """Get via attribute name."""
         return self[name]
 
     def __setattr__(self, name, value):
+        """Set via attribute name."""
         self[name] = value
 
     def __delattr__(self, name):
+        """Delete via attribute name."""
         del self[name]
 
 
 class App(Command):
+    """
+    :class:`clik.Command` subclass that implements the :meth:`main` method.
+
+    :meth:`main` is the user-level API for starting the application.
+    """
+
     def __init__(self, fn, name=None):
+        """
+        Initialize the application object.
+
+        :param fn: Main application generator function.
+        :param name: Optional :class:`str` specifying the application name.
+                     If not specified the application name is set to
+                     ``fn.__name__``.
+        """
         super(App, self).__init__(Context(), fn, name=name)
 
     def main(self, argv=None, exit=sys.exit):
+        """
+        Start the application.
+
+        :param argv: Optional list of command-line arguments. If not specified,
+                     this defaults to ``sys.argv``.
+        :param exit: Optional function to call on exit. If not specified,
+                     this defaults to :func:`sys.exit`.
+        :type exit: ``fn(integer_exit_code)``
+        :return: Return value of ``exit``
+        """
         if argv is None:  # pragma: no cover (hard to test, obviously correct)
             argv = sys.argv
 

--- a/src/clik/argparse.py
+++ b/src/clik/argparse.py
@@ -162,7 +162,9 @@ class ArgumentParser(argparse.ArgumentParser):
 
 
 if PY33 or PY26:  # pragma: no cover (~copypaste of Python 3.4 implementation)
-    def __call__(self, parser, namespace, values, option_string=None):
+    # LINT: Ignore undocumented function violation. Compatibility code is not
+    #       formally documented.
+    def __call__(self, parser, namespace, values, option_string=None):  # noqa
         parser_name = values[0]
         arg_strings = values[1:]
 
@@ -194,7 +196,9 @@ if PY33 or PY26:  # pragma: no cover (~copypaste of Python 3.4 implementation)
 if PY2:
     original_error = ArgumentParser.error
 
-    def error(self, message=None):
+    # LINT: Ignore undocumented function violation. Compatibility code is not
+    #       formally documented.
+    def error(self, message=None):  # noqa: D103
         if message == 'too few arguments':
             for action in self._actions:  # pragma: no branch (unreachable)
                 if isinstance(action, argparse._SubParsersAction):
@@ -212,7 +216,9 @@ if PY2:
 
     # https://gist.github.com/sampsyo/471779
 
-    class _AliasedSubParsersPseudoAction(argparse.Action):
+    # LINT: Ignore undocumented function violation. Compatibility code is not
+    #       formally documented.
+    class _AliasedSubParsersPseudoAction(argparse.Action):  # noqa: D103
         def __init__(self, name, aliases, help):
             dest = name
             if aliases:
@@ -222,7 +228,9 @@ if PY2:
 
     original_add_parser = argparse._SubParsersAction.add_parser
 
-    def add_parser(self, name, **kwargs):
+    # LINT: Ignore undocumented function violation. Compatibility code is not
+    #       formally documented.
+    def add_parser(self, name, **kwargs):  # noqa: D103
         aliases = kwargs.pop('aliases')
         parser = original_add_parser(self, name, **kwargs)
         for alias in aliases:

--- a/src/clik/compat.py
+++ b/src/clik/compat.py
@@ -13,18 +13,20 @@ PY2 = sys.version_info[0] == 2
 PY26 = sys.version_info[0:2] == (2, 6)
 PY33 = sys.version_info[0:2] == (3, 3)
 
+# LINT: Ignore undocumented function violations. Compatibility code is not
+#       formally documented.
 
 if PY2:
-    def iteritems(d, *args, **kwargs):
+    def iteritems(d, *args, **kwargs):  # noqa: D103
         return d.iteritems(*args, **kwargs)
 
-    def implements_bool(cls):
+    def implements_bool(cls):  # noqa: D103
         cls.__nonzero__ = cls.__bool__
         del cls.__bool__
         return cls
 else:
-    def iteritems(d, *args, **kwargs):
+    def iteritems(d, *args, **kwargs):  # noqa: D103
         return iter(d.items(*args, **kwargs))
 
-    def implements_bool(cls):
+    def implements_bool(cls):  # noqa: D103
         return cls

--- a/src/clik/compat.py
+++ b/src/clik/compat.py
@@ -3,7 +3,7 @@
 Compatibility helpers, inspired by Werkzeug's _compat module.
 
 :author: Joe Joyce <joe@decafjoe.com>
-:copyright: Copyright (c) Joe Joyce, 2009-2017.
+:copyright: Copyright (c) Joe Joyce and contributors, 2009-2017.
 :license: BSD
 """
 import sys

--- a/src/clik/context.py
+++ b/src/clik/context.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-
+Manage bindings for :class:`clik.magic.Magic` variables.
 
 :author: Joe Joyce <joe@decafjoe.com>
 :copyright: Copyright (c) Joe Joyce and contributors, 2009-2017.
@@ -12,40 +12,86 @@ from clik.compat import iteritems
 
 
 class LockedMagicError(Exception):
+    """Raised when trying to acquire a magvar that is already acquired."""
+
     def __init__(self, name):
+        """
+        Initialize the exception.
+
+        :param str name: Name of the magic variable that is locked.
+        """
         msg = 'The magic variable "%s" is currently locked' % name
         super(LockedMagicError, self).__init__(msg)
         self.name = name
 
 
 class MagicNameConflictError(Exception):
+    """Raised when trying to register an already-registered magvar."""
+
     def __init__(self, name):
+        """
+        Initialize the exception.
+
+        :param str name: Name of the magic variable that is already registered.
+        """
         msg = 'The magic variable name "%s" is already registered' % name
         super(MagicNameConflictError, self).__init__(msg)
         self.name = name
 
 
 class UnregisteredMagicNameError(Exception):
+    """Raised when trying to access an unregistered magic variable."""
+
     def __init__(self, name):
+        """
+        Initialize the exception.
+
+        :param str name: Name of the unregistered magic variable the caller
+                         was attempting to access.
+        """
         msg = 'The magic variable "%s" is not registered' % name
         super(UnregisteredMagicNameError, self).__init__(msg)
         self.name = name
 
 
 class UnboundMagicError(Exception):
+    """Raised when trying to access a magic variable that is not bound."""
+
     def __init__(self, name):
+        """
+        Initialize the exception.
+
+        :param str name: Name of the unbound magic variable the caller was
+                         attempting to access.
+        """
         msg = 'The magic variable "%s" is not bound' % name
         super(UnboundMagicError, self).__init__(msg)
         self.name = name
 
 
 class Context(object):
+    """Bindings manager for magic variables."""
+
     def __init__(self):
+        """Initialize the context."""
         self._registry = []
         self._state = {}
 
     @contextlib.contextmanager
     def __call__(self, **kwargs):
+        """
+        Context manager for :meth:`push` -ing ``kwargs`` during a code block.
+
+        Example::
+
+           context = Context()
+           context.register('foo')
+           with context(foo='bar'):
+               pass  # do some stuff
+
+        Before the block, each key/value pair in ``kwargs`` is passed to
+        :meth:`push`. After the block, each key is :meth:`pop` -ped.
+        """
         keys = []
         for key, value in iteritems(kwargs):
             self.push(key, value)
@@ -56,6 +102,34 @@ class Context(object):
 
     @contextlib.contextmanager
     def acquire(self, *magic_variables):
+        """
+        Context manager to lock ``magic_variables`` from use by other contexts.
+
+        Only one context at a time is allowed to control the binding of a magic
+        variable. Using this context manager ensures the caller can safely
+        manipulate the binding without interference from other contexts::
+
+           foo = Magic('foo')
+           context1 = Context()
+           context1.register('foo')
+           context2 = Context()
+           context2.register('foo')
+           with context1.acquire(foo):
+               with context1(foo='bar'):
+                   pass  # do some stuff
+               with context2.acquire(foo):
+                   # BOOM! LockedMagicError gets thrown
+
+        Before the block, each of the ``magic_variables`` is checked to see if
+        it currently has a context. If so, :exc:`LockedMagicError` is thrown.
+        Otherwise, the context is set to this instance.
+
+        After the block, the context for each magic variable is reset to
+        ``None``, freeing it up for use by other contexts.
+
+        :raise: :exc:`LockedMagicError` if one of ``magic_variables`` is
+                already acquired
+        """
         for variable in magic_variables:
             if variable._Magic__context is not None:
                 raise LockedMagicError(variable._Magic__context)
@@ -73,28 +147,67 @@ class Context(object):
             raise UnregisteredMagicNameError(name)
 
     def get(self, name):
+        """
+        Return currently-bound value of magic variable named ``name``.
+
+        :param str name: Name of magic variable.
+        :raise: :exc:`UnregisteredMagicNameError` if ``name`` is not registered
+        :raise: :exc:`UnboundMagicError` if variable is not currently bound
+        """
         self._assert_in_registry(name)
         if not self._state[name]:
             raise UnboundMagicError(name)
         return self._state[name][0]
 
-    def push(self, name, object):
+    def push(self, name, obj):
+        """
+        Push a value on to a variable's stack, rebinding its current value.
+
+        :param str name: Name of magic variable.
+        :param obj: New value to push on to the stack.
+        :raise: :exc:`UnregisteredMagicNameError` if ``name`` is not registered
+        """
         self._assert_in_registry(name)
-        self._state[name].insert(0, object)
+        self._state[name].insert(0, obj)
 
     def pop(self, name):
+        """
+        Pop and return the current value off the variable's stack.
+
+        This rebinds the variable to the next-highest item on the stack.
+
+        :param str name: Name of magic variable.
+        :raise: :exc:`UnregisteredMagicNameError` if ``name`` is not registered
+        :raise: :exc:`UnboundMagicError` if variable is not currently bound
+        """
         self._assert_in_registry(name)
         if not self._state[name]:
             raise UnboundMagicError(name)
         return self._state[name].pop(0)
 
     def register(self, name):
+        """
+        Register a magic variable name.
+
+        Requiring registration prevents accidental conflicts between modules.
+        If two modules (which may not know about each other) both try to
+        register the same magic variable, clik will thrown an exception.
+
+        :param str name: Name of magic variable.
+        :raise: :exc:`MagicNameConflictError` if ``name`` is already registered
+        """
         if name in self._registry:
             raise MagicNameConflictError(name)
         self._registry.append(name)
         self._state[name] = []
 
     def unregister(self, name):
+        """
+        Unregister a magic variable name.
+
+        :param str name: Name of magic variable.
+        :raise: :exc:`UnregisteredMagicNameError` if ``name`` is not registered
+        """
         self._assert_in_registry(name)
         self._registry.remove(name)
         del self._state[name]

--- a/src/clik/magic.py
+++ b/src/clik/magic.py
@@ -38,13 +38,14 @@ Original code licensed from the Werkzeug Team under the following terms:
 :authors: See Werkzeug's AUTHORS file
 :license: BSD
 """
+# flake8: noqa
 import copy
 
 from clik.compat import implements_bool, PY2
 
 
 @implements_bool
-class Magic(object):  # pragma: no cover (werkzeug implementation)
+class Magic(object):  # pragma: no cover
     def __init__(self, name):
         object.__setattr__(self, '_Magic__context', None)
         object.__setattr__(self, '_Magic__name', name)

--- a/src/test/unit/test_app.py
+++ b/src/test/unit/test_app.py
@@ -3,7 +3,7 @@
 Test the :mod:`clik.app` module.
 
 :author: Joe Joyce <joe@decafjoe.com>
-:copyright: Copyright (c) Joe Joyce, 2009-2017.
+:copyright: Copyright (c) Joe Joyce and contributors, 2009-2017.
 :license: BSD
 """
 import pytest
@@ -12,6 +12,7 @@ from clik.app import AttributeDict
 
 
 def test_attribute_dict():
+    """Test that :class:`clik.app.AtributeDict` behaves properly."""
     d = AttributeDict()
     assert d == {}
     d.foo = 'bar'

--- a/src/test/unit/test_command.py
+++ b/src/test/unit/test_command.py
@@ -3,7 +3,7 @@
 Test the :mod:`clik.command` module.
 
 :author: Joe Joyce <joe@decafjoe.com>
-:copyright: Copyright (c) Joe Joyce, 2009-2017.
+:copyright: Copyright (c) Joe Joyce and contributors, 2009-2017.
 :license: BSD
 """
 import pytest
@@ -13,6 +13,7 @@ from clik.command import BareAlreadyRegisteredError
 
 
 def test_bare_already_registered_error():
+    """Test that registering two bare commands raises an exception."""
     @app
     def dummy():
         yield

--- a/src/test/unit/test_context.py
+++ b/src/test/unit/test_context.py
@@ -3,7 +3,7 @@
 Test the :mod:`clik.context` module.
 
 :author: Joe Joyce <joe@decafjoe.com>
-:copyright: Copyright (c) Joe Joyce, 2009-2017.
+:copyright: Copyright (c) Joe Joyce and contributors, 2009-2017.
 :license: BSD
 """
 import pytest
@@ -14,6 +14,7 @@ from clik.magic import Magic
 
 
 def test_context():
+    """Test all the behavior and corner cases of contexts."""
     context = Context()
     a = Magic('a')
     with context.acquire(a):

--- a/tool/marc.py
+++ b/tool/marc.py
@@ -6,15 +6,13 @@ The cram format is great, but after much fooling around with trying to get
 cram working with coverage, I realized I could implement the tiny subset I
 was using in a little tool that integrated coverage. So marc was born.
 
-
 :author: Joe Joyce <joe@decafjoe.com>
-:copyright: Copyright (c) Joe Joyce, 2009-2017.
+:copyright: Copyright (c) Joe Joyce and contributors, 2009-2017.
 :license: BSD
 """
 from __future__ import print_function
 import difflib
 import fnmatch
-import io
 import os
 import re
 import shlex
@@ -27,7 +25,10 @@ except ImportError:
 
 
 class Test(object):
+    """Test case."""
+
     def __init__(self, newlines, start_line, app, argv, invocation):
+        """Initialize test case."""
         self.newlines = newlines
         self.start_line = start_line
         self.app = app
@@ -39,6 +40,7 @@ class Test(object):
         self.actual_exit_code = None
 
     def run(self):
+        """Run test case."""
         exit_rvs = []
 
         def exit(rv):
@@ -65,6 +67,8 @@ class Test(object):
 
 
 class TestFile(object):
+    """Functional test case."""
+
     suffix = '.t'
     invocation_re = re.compile(r'^\$ dummy(?P<argv>.+)?$')
     exit_code_re = re.compile(r'^\[(?P<exit_code>\d+)\]$')
@@ -72,6 +76,13 @@ class TestFile(object):
 
     @classmethod
     def discover(cls, path):
+        """
+        Auto-discover test files within ``path``.
+
+        :param str path: Path to directory or file.
+        :return: :class:`list` of :class:`TestFile` instances for each test
+                 case in ``path``.
+        """
         if os.path.isdir(path):
             rv = []
             for directory, _, filenames in os.walk(path):
@@ -82,6 +93,11 @@ class TestFile(object):
             return [cls(path)]
 
     def __init__(self, path):
+        """
+        Initialize functional test.
+
+        :param str path: Base path to the test.
+        """
         self.path = path
         self.script_path = '%s.py' % self.path[:-len(self.suffix)]
         self.name = path.rsplit('functional', 1)[1][1:-len(self.suffix)]
@@ -89,6 +105,7 @@ class TestFile(object):
         self.result = '?'
 
     def run(self):
+        """Run this test."""
         if os.path.exists(self.script_path):
             with open(self.script_path) as f:
                 g = {}
@@ -165,6 +182,7 @@ class TestFile(object):
 
 
 def main(argv=None, exit=sys.exit):
+    """Entry point for the tool."""
     if argv is None:
         argv = sys.argv
 
@@ -183,7 +201,7 @@ def main(argv=None, exit=sys.exit):
         print('error: no tests discovered for %s' % path, file=sys.stderr)
         exit(1)
     test_files = sorted(test_files, key=lambda tf: tf.name)
-    
+
     for test_file in test_files:
         test_file.run()
         print(test_file.result, end='')

--- a/tool/pre-release
+++ b/tool/pre-release
@@ -63,7 +63,7 @@ if [ $local_commit != $remote_commit ]; then
 fi
 
 echo
-read -p 'Is the CHANGELOG.rst file up to date and ready to go? [y/N] ' yn
+read -p 'Is the doc/changelog.rst file up to date and ready to go? [y/N] ' yn
 if [ x"$yn" != xy ]; then
     exit 1
 fi

--- a/tool/test
+++ b/tool/test
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
 """
+Test runner for clik.
+
+:author: Joe Joyce <joe@decafjoe.com>
+:copyright: Copyright (c) Joe Joyce and contributors, 2009-2017.
+:license: BSD
 """
 from __future__ import print_function
 import argparse
@@ -11,6 +16,8 @@ import subprocess
 import sys
 
 
+#: Primary interpreter for development environment. Must match
+#: ``PYTHON_VERSION`` in the top-level ``Makefile``.
 DEFAULT_INTERPRETER = 'py36'
 
 
@@ -24,7 +31,7 @@ functional_test_re = re.compile(r'^(?P<n>\d{4})-?(?P<name>[\w-]+)?(\..+)?$')
 
 
 def main(argv=None, exit=sys.exit):
-    """Convenience wrapper for running tests."""
+    """Entry point for the tool."""
     if argv is None:
         argv = sys.argv
 
@@ -127,7 +134,7 @@ def main(argv=None, exit=sys.exit):
         glob += kind if kind else '*'
         selected_envs = fnmatch.filter(envs, glob)
         if len(selected_envs) < 1:
-            pass # TODO: unknown interpreter, error out
+            pass  # noqa: T000 (TODO: unknown interpreter, error out)
         envs_arg = '-e %s' % ','.join(selected_envs)
     if envs_arg:
         envs_arg += ',cover'


### PR DESCRIPTION
This set of commits brings the codebase into compliance with the project style guide.

Several notable policy decisions were made in cleaning up the code.

* `noqa` must be scoped to individual violation code(s) unless line length limitations prevent the code(s) from being specified
* `noqa` must be accompanied by a `LINT:` comment explaining why the violation is excepted
* Compatibility code does not require docstrings – see 8e9df2c0 for rationale

I make no representations about the quality of the docstrings in this pull request. The major focus was to get rid of linter violations with an eye toward integrating linting with Travis. A later pass will pull the docstrings into the documentation (probably in an _Internal API_ document or somesuch) at which point the docstrings can be polished up.
