### PR TITLE
Integrate Flake8 Linter into Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,30 @@
 ---
+sudo: false
+notifications:
+  on_success: change
+  on_failure: always
+
 language: python
-python:
-  - "pypy3"
-  - "pypy"
-  - "3.6"
-  - "3.5"
-  - "3.4"
-  - "3.3"
-  - "2.7"
-  - "2.6"
-install:
-  - make env
-  - pip install tox-travis
+install: pip install tox-travis
 script: tox
+
+matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=lint TRAVIS=yes
+    - python: pypy3
+      env: TOXENV=pypy3-functional,pypy3-unit TRAVIS=yes
+    - python: pypy
+      env: TOXENV=pypy-functional,pypy-unit TRAVIS=yes
+    - python: 3.6
+      env: TOXENV=py36-functional,py36-unit TRAVIS=yes
+    - python: 3.5
+      env: TOXENV=py35-functional,py35-unit TRAVIS=yes
+    - python: 3.4
+      env: TOXENV=py34-functional,py34-unit TRAVIS=yes
+    - python: 3.3
+      env: TOXENV=py33-functional,py33-unit TRAVIS=yes
+    - python: 2.7
+      env: TOXENV=py27-functional,py27-unit TRAVIS=yes
+    - python: 2.6
+      env: TOXENV=py26-functional,py26-unit TRAVIS=yes

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ lint : env
 test : lint
 	$(TOOL)/test
 
-test-all : lint
+test-all : env
 	$(TOOL)/test -a
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = {py26,py27,py33,py34,py35,py36,pypy,pypy3}-{functional,unit}, cover
+envlist =
+        {py26,py27,py33,py34,py35,py36,pypy,pypy3}-{functional,unit},
+        cover,
+        lint
 
 
 [functional]
@@ -39,6 +42,16 @@ commands = coverage combine \
            coverage html \
              --rcfile {toxinidir}/coveragerc \
              --directory {toxinidir}/coverage
+
+[testenv:lint]
+deps = -r{toxinidir}/requirements.txt
+commands = flake8 --ignore=D203 \
+         {toxinidir}/setup.py \
+         {toxinidir}/doc/conf.py \
+         {toxinidir}/src/clik \
+         {toxinidir}/src/test/unit \
+         {toxinidir}/tool/marc.py \
+         {toxinidir}/tool/test
 
 
 [testenv:py26-functional]


### PR DESCRIPTION
The `matrix` part of the config file is shamelessly ripped off from a PyCQA project.